### PR TITLE
[Merged by Bors] - Fix/ssl not enabled inbuild time

### DIFF
--- a/crates/kafka-sink/Cargo.toml
+++ b/crates/kafka-sink/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 tempfile = { version = "3.8", default-features = false, features = [] }
 
 rdkafka-sys = { version = "4.5.0+1.9.2" }
-rdkafka = { version ="0.33.0", features = ["libz-static", "tokio"], default-features = false  }
+rdkafka = { version ="0.33.0", features = ["libz-static", "tokio", "ssl-vendored"], default-features = false  }
 openssl = { version = "0.10", features = ["vendored"] }
 
 

--- a/crates/kafka-sink/Connector.toml
+++ b/crates/kafka-sink/Connector.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kafka-sink"
 group = "infinyon"
-version = "0.2.6"
+version = "0.2.7"
 apiVersion = "0.1.0"
 fluvio = "0.10.14"
 description = "Kafka sink connector"

--- a/crates/kafka-sink/README.md
+++ b/crates/kafka-sink/README.md
@@ -29,7 +29,7 @@ Example without security:
 ```yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.2.6
+  version: 0.2.7
   name: my-kafka-connector
   type: kafka-sink
   topic: kafka-topic
@@ -44,7 +44,7 @@ Example with security enabled:
 ```yaml
 apiVersion: 0.1.0
 meta:
-  version: 0.2.6
+  version: 0.2.7
   name: my-kafka-connector
   type: kafka-sink
   topic: kafka-topic


### PR DESCRIPTION
SSL is no longer enabled by default in `rdkafka` crate. We need to enable it explicitly, otherwise it fails in runtime.