### PR TITLE
[Merged by Bors] - chore: ignore rdkafka crate from dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "rdkafka-sys"
+      - dependency-name: "rdkafka"


### PR DESCRIPTION
Ignore `rdkafka` crate from dependabot checks. Until we have integration tests we should check manually all updates related to this crate.