### PR TITLE
chore: downgrade rdkafka crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,12 +2345,11 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.36.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+checksum = "8a22ce72c78b471baba6c75bda6e03511ef2ee1bae3729902d2bb38951db1048"
 dependencies = [
- "futures-channel",
- "futures-util",
+ "futures",
  "libc",
  "log",
  "rdkafka-sys",
@@ -2363,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.7.0+2.3.0"
+version = "4.0.0+1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
+checksum = "54f24572851adfeb525fdc4a1d51185898e54fed4e8d8dba4fadb90c6b4f0422"
 dependencies = [
  "cmake",
  "libc",

--- a/crates/kafka-sink/Cargo.toml
+++ b/crates/kafka-sink/Cargo.toml
@@ -18,11 +18,15 @@ tempfile = { version = "3.10", default-features = false, features = [] }
 
 # Features `ssl` or `ssl-vendored` must be enabled explicitely, otherwise it fails runtime with enabled ssl.
 # Before changing version make sure it compiles on *-unknown-linux-musl targets.
-rdkafka-sys = { version = "=4.7.0+2.3.0" }
-rdkafka = { version ="0.36", features = ["libz-static", "tokio", "ssl-vendored"], default-features = false  }
+rdkafka-sys = { version = "=4.0.0+1.6.1" }
+rdkafka = { version ="0.27", features = ["libz-static", "tokio", "ssl-vendored"], default-features = false  }
 
 fluvio = { workspace = true }
 fluvio-connector-common = { workspace = true }
 
 [target.aarch64-apple-darwin.dependencies]
-rdkafka = { version ="0.36", features = ["libz-static", "tokio", "cmake-build", "ssl-vendored"], default-features = false  }
+rdkafka = { version ="0.27", features = ["libz-static", "tokio", "cmake-build", "ssl-vendored"], default-features = false  }
+
+[target.x86_64-apple-darwin.dependencies]
+rdkafka = { version ="0.27", features = ["libz-static", "tokio", "cmake-build", "ssl-vendored"], default-features = false  }
+


### PR DESCRIPTION
Upgrade rdkafka to > 0.27 broke musl targets compilation. 

Rolled back to the latest version that is successfully compiled on all our targets.